### PR TITLE
mac stuff. also, better pip instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Python has two amazing tools, called `virtualenv` and `pip` that enable develope
 * Ubuntu: 
         ```curl -O http://python-distribute.org/distribute_setup.py
         python distribute_setup.py
-        curl -O https://raw.github.com/pypa/pip/master/contrib/get-pip.py`
+        curl -O https://raw.github.com/pypa/pip/master/contrib/get-pip.py
         python get-pip.py```
 * OSX: Pip comes with Homebrew, no special setup needed.
 * Windows: insert Windows installation here

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Python has two amazing tools, called `virtualenv` and `pip` that enable develope
 `pip` is something called a "package manage" that allows you to actually install libraries from online. Suppose I want to use a library that parses PDFs for me. BAM! `pip install pdfminer`. If I want a library that scrapes web pages for me: BAM! `pip install beautifulsoup`. You get the idea. `pip` stores all the awesome libraries that people have built for Python and with a single command, you get access to them. Here's how to install it:
 
 * Ubuntu: 
-`curl -O http://python-distribute.org/distribute_setup.py
-python distribute_setup.py
-curl -O https://raw.github.com/pypa/pip/master/contrib/get-pip.py
-python get-pip.py`
+`curl -O http://python-distribute.org/distribute_setup.py`
+`python distribute_setup.py`
+`curl -O https://raw.github.com/pypa/pip/master/contrib/get-pip.py`
+`python get-pip.py`
 * OSX: Pip comes with Homebrew, no special setup needed.
 * Windows: insert Windows installation here
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Python has two amazing tools, called `virtualenv` and `pip` that enable develope
 
 `pip` is something called a "package manage" that allows you to actually install libraries from online. Suppose I want to use a library that parses PDFs for me. BAM! `pip install pdfminer`. If I want a library that scrapes web pages for me: BAM! `pip install beautifulsoup`. You get the idea. `pip` stores all the awesome libraries that people have built for Python and with a single command, you get access to them. Here's how to install it:
 
-* Linux: $ `sudo apt-get install python-setuptools python-pip`
+* Linux: `$ sudo apt-get install python-setuptools python-pip`
 * OSX: Pip comes with Homebrew, no special setup needed.
 * Windows: insert Windows installation here
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ Python has two amazing tools, called `virtualenv` and `pip` that enable develope
 
 `pip` is something called a "package manage" that allows you to actually install libraries from online. Suppose I want to use a library that parses PDFs for me. BAM! `pip install pdfminer`. If I want a library that scrapes web pages for me: BAM! `pip install beautifulsoup`. You get the idea. `pip` stores all the awesome libraries that people have built for Python and with a single command, you get access to them. Here's how to install it:
 
-* Ubuntu: ```curl -O http://python-distribute.org/distribute_setup.py
-python distribute_setup.py
-curl -O https://raw.github.com/pypa/pip/master/contrib/get-pip.py`
-python get-pip.py```
+* Ubuntu: 
+        ```curl -O http://python-distribute.org/distribute_setup.py
+        python distribute_setup.py
+        curl -O https://raw.github.com/pypa/pip/master/contrib/get-pip.py`
+        python get-pip.py```
 * OSX: Pip comes with Homebrew, no special setup needed.
 * Windows: insert Windows installation here
 

--- a/README.md
+++ b/README.md
@@ -30,15 +30,10 @@ Python has two amazing tools, called `virtualenv` and `pip` that enable develope
 
 `pip` is something called a "package manage" that allows you to actually install libraries from online. Suppose I want to use a library that parses PDFs for me. BAM! `pip install pdfminer`. If I want a library that scrapes web pages for me: BAM! `pip install beautifulsoup`. You get the idea. `pip` stores all the awesome libraries that people have built for Python and with a single command, you get access to them. Here's how to install it:
 
-* Ubuntu: 
-
-`curl -O http://python-distribute.org/distribute_setup.py`
-
-`python distribute_setup.py`
-
-`curl -O https://raw.github.com/pypa/pip/master/contrib/get-pip.py`
-
-`python get-pip.py`
+* Ubuntu: ```curl -O http://python-distribute.org/distribute_setup.py
+python distribute_setup.py
+curl -O https://raw.github.com/pypa/pip/master/contrib/get-pip.py`
+python get-pip.py```
 * OSX: Pip comes with Homebrew, no special setup needed.
 * Windows: insert Windows installation here
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Python has two amazing tools, called `virtualenv` and `pip` that enable develope
 `pip` is something called a "package manage" that allows you to actually install libraries from online. Suppose I want to use a library that parses PDFs for me. BAM! `pip install pdfminer`. If I want a library that scrapes web pages for me: BAM! `pip install beautifulsoup`. You get the idea. `pip` stores all the awesome libraries that people have built for Python and with a single command, you get access to them. Here's how to install it:
 
 * Ubuntu: 
+
         `curl -O http://python-distribute.org/distribute_setup.py
 
         python distribute_setup.py

--- a/README.md
+++ b/README.md
@@ -40,15 +40,11 @@ Step 1: Learn and install Python
 
 The rest of the guide will assume some basic knowledge of the Python 2 language. Hopefully you've picked up some Python from 61A, but if you haven't, head over to the official Python [tutorial](http://docs.python.org/tutorial), which is pretty good! 
 
-<<<<<<< HEAD
 You need to install Python 2.7 to complete this hack. You can do that for Windows [here](http://www.python.org/download/releases/2.7/).
-=======
-You need to install Python 2.7 to complete this hack. You can do that [here](http://www.python.org/download/releases/2.7/). If you have OSX, you already should have Python 2.7 installed.
->>>>>>> upstream/master
 
 For Linux, it probably comes with your distribution, but if you need to, install it from your pacakge repositories. For Debian based distros, including Ubuntu, this probably is `sudo apt-get install python`.
 
-For Mac OS X, Python comes with your operating system, but the default python may be out of date. Get the newest version via [Homebrew](http://brew.sh). After homebrew is properly installed, run `brew install python --with-brewed-openssl` to install python.
+For Mac OS X, Python comes with your operating system, but the default python may be out of date- OS X comes with a version of Python 2 that's a couple years out of date due to legal reasons. Get the newest version via [Homebrew](http://brew.sh). After homebrew is properly installed, run `brew install python --with-brewed-openssl` to install python.
 
 Step 1.5: Set up Pip
 ================================
@@ -59,13 +55,8 @@ Python has two amazing tools, called `virtualenv` and `pip` that enable develope
 
 `pip` is something called a "package manage" that allows you to actually install libraries from online. Suppose I want to use a library that parses PDFs for me. BAM! `pip install pdfminer`. If I want a library that scrapes web pages for me: BAM! `pip install beautifulsoup`. You get the idea. `pip` stores all the awesome libraries that people have built for Python and with a single command, you get access to them. Here's how to install it:
 
-<<<<<<< HEAD
 * Linux: `$ sudo apt-get install python-setuptools python-pip`
 * OSX: Pip comes with Homebrew, no special setup needed.
-=======
-* Ubuntu: `sudo apt-get install python-setuptools`
-* OSX: You're in luck! OSX comes with Python 2.7 and setuptools already installed.
->>>>>>> upstream/master
 * Windows: insert Windows installation here
 
 Step 2: Set up your environment

--- a/README.md
+++ b/README.md
@@ -32,8 +32,11 @@ Python has two amazing tools, called `virtualenv` and `pip` that enable develope
 
 * Ubuntu: 
         ```curl -O http://python-distribute.org/distribute_setup.py
+
         python distribute_setup.py
+
         curl -O https://raw.github.com/pypa/pip/master/contrib/get-pip.py
+        
         python get-pip.py```
 * OSX: Pip comes with Homebrew, no special setup needed.
 * Windows: insert Windows installation here

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ Python has two amazing tools, called `virtualenv` and `pip` that enable develope
 `pip` is something called a "package manage" that allows you to actually install libraries from online. Suppose I want to use a library that parses PDFs for me. BAM! `pip install pdfminer`. If I want a library that scrapes web pages for me: BAM! `pip install beautifulsoup`. You get the idea. `pip` stores all the awesome libraries that people have built for Python and with a single command, you get access to them. Here's how to install it:
 
 * Ubuntu: 
-        ```curl -O http://python-distribute.org/distribute_setup.py
+        `curl -O http://python-distribute.org/distribute_setup.py
 
         python distribute_setup.py
 
         curl -O https://raw.github.com/pypa/pip/master/contrib/get-pip.py
-        
-        python get-pip.py```
+
+        python get-pip.py`
 * OSX: Pip comes with Homebrew, no special setup needed.
 * Windows: insert Windows installation here
 

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ Python has two amazing tools, called `virtualenv` and `pip` that enable develope
 
 * Ubuntu: 
 
-        `curl -O http://python-distribute.org/distribute_setup.py
+        curl -O http://python-distribute.org/distribute_setup.py
 
         python distribute_setup.py
 
         curl -O https://raw.github.com/pypa/pip/master/contrib/get-pip.py
 
-        python get-pip.py`
+        python get-pip.py
 * OSX: Pip comes with Homebrew, no special setup needed.
 * Windows: insert Windows installation here
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,13 @@ Python has two amazing tools, called `virtualenv` and `pip` that enable develope
 `pip` is something called a "package manage" that allows you to actually install libraries from online. Suppose I want to use a library that parses PDFs for me. BAM! `pip install pdfminer`. If I want a library that scrapes web pages for me: BAM! `pip install beautifulsoup`. You get the idea. `pip` stores all the awesome libraries that people have built for Python and with a single command, you get access to them. Here's how to install it:
 
 * Ubuntu: 
+
 `curl -O http://python-distribute.org/distribute_setup.py`
+
 `python distribute_setup.py`
+
 `curl -O https://raw.github.com/pypa/pip/master/contrib/get-pip.py`
+
 `python get-pip.py`
 * OSX: Pip comes with Homebrew, no special setup needed.
 * Windows: insert Windows installation here

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ You need to install Python 2.7 to complete this hack. You can do that for Window
 
 For Linux, it probably comes with your distribution, but if you need to, install it from your pacakge repositories. For Debian based distros, including Ubuntu, this probably is `sudo apt-get install python`.
 
-For Mac OS X, Python comes with your operating system, but the default python may be out of date. Get the newest version via [Homebrew](http://brew.sh). After homebrew is properly installed, run `brew install python --with-brewed-openssl
-` to install python.
+For Mac OS X, Python comes with your operating system, but the default python may be out of date. Get the newest version via [Homebrew](http://brew.sh). After homebrew is properly installed, run `brew install python --with-brewed-openssl` to install python.
 
 Step 1.5: Set up Pip
 ================================
@@ -30,15 +29,7 @@ Python has two amazing tools, called `virtualenv` and `pip` that enable develope
 
 `pip` is something called a "package manage" that allows you to actually install libraries from online. Suppose I want to use a library that parses PDFs for me. BAM! `pip install pdfminer`. If I want a library that scrapes web pages for me: BAM! `pip install beautifulsoup`. You get the idea. `pip` stores all the awesome libraries that people have built for Python and with a single command, you get access to them. Here's how to install it:
 
-* Ubuntu: 
-
-        curl -O http://python-distribute.org/distribute_setup.py
-
-        python distribute_setup.py
-
-        curl -O https://raw.github.com/pypa/pip/master/contrib/get-pip.py
-
-        python get-pip.py
+* Linux: $ `sudo apt-get install python-setuptools python-pip`
 * OSX: Pip comes with Homebrew, no special setup needed.
 * Windows: insert Windows installation here
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,15 @@ Step 1: Learn and install Python
 
 The rest of the guide will assume some basic knowledge of the Python 2 language. Hopefully you've picked up some Python from 61A, but if you haven't, head over to the official Python [tutorial](http://docs.python.org/tutorial), which is pretty good! 
 
-You need to install Python 2.7 to complete this hack. You can do that [here](http://www.python.org/download/releases/2.7/).
+You need to install Python 2.7 to complete this hack. You can do that for Windows [here](http://www.python.org/download/releases/2.7/).
+
+For Linux, it probably comes with your distribution, but if you need to, install it from your pacakge repositories. For Debian based distros, including Ubuntu, this probably is `sudo apt-get install python`.
+
+For Mac OS X, Python comes with your operating system, but the default python may be out of date. Get the newest version via [Homebrew](http://brew.sh). The installation command is: `ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go)"` followed with an `brew install python --with-brewed-openssl
+` to install python.
+
+
+^*DO NOT INSTALL IF YOU HAVE PREVIOUSLY INSTALLED MACPORTS. BAD THINGS WILL HAPPEN.
 
 Step 2: Set up your environment
 ================================
@@ -26,7 +34,7 @@ Python has two amazing tools, called `virtualenv` and `pip` that enable develope
 The first thing you need is to make sure you have a Python package called `setuptools` installed. Here's how to install it:
 
 * Ubuntu: `sudo apt-get install python-setuptools`
-* OSX: insert OSX installation here
+* OSX: `ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go)"`
 * Windows: insert Windows installation here
 
 
@@ -35,7 +43,7 @@ Installing `setuptools` will give you a command line tool called `easy_install`,
 
 Enter the following in your terminal to install `virtualenv`.
 ```
-$ sudo easy_install virtualenv
+$ pip install virtualenv
 ```
 
 Now a quick word about `virtualenv`. It's a Python tool that allows you to create "sandboxes," or isolated environments in which you can code. When you need a Python library, you could install it globally, which means all your Python projects on your computer could use it. You could also install it locally, which means you install libraries on a project-by-project basis and no project will have any more dependencies available than it needs. The "sandbox" mentality means that we make sure each project stands alone, which means a lot when you may want to deploy these projects to remote computers.

--- a/README.md
+++ b/README.md
@@ -18,28 +18,30 @@ You need to install Python 2.7 to complete this hack. You can do that for Window
 
 For Linux, it probably comes with your distribution, but if you need to, install it from your pacakge repositories. For Debian based distros, including Ubuntu, this probably is `sudo apt-get install python`.
 
-For Mac OS X, Python comes with your operating system, but the default python may be out of date. Get the newest version via [Homebrew](http://brew.sh). The installation command is: `ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go)"` followed with an `brew install python --with-brewed-openssl
+For Mac OS X, Python comes with your operating system, but the default python may be out of date. Get the newest version via [Homebrew](http://brew.sh). After homebrew is properly installed, run `brew install python --with-brewed-openssl
 ` to install python.
 
-
-^*DO NOT INSTALL IF YOU HAVE PREVIOUSLY INSTALLED MACPORTS. BAD THINGS WILL HAPPEN.
-
-Step 2: Set up your environment
+Step 1.5: Set up Pip
 ================================
 
 Before any hack, you need to make sure all your dependencies are set up. 
 
 Python has two amazing tools, called `virtualenv` and `pip` that enable developers to create sandboxes for their projects and easily install any online packages and libraries that other people have written. We'll be using mainly these two tools.
 
-The first thing you need is to make sure you have a Python package called `setuptools` installed. Here's how to install it:
+`pip` is something called a "package manage" that allows you to actually install libraries from online. Suppose I want to use a library that parses PDFs for me. BAM! `pip install pdfminer`. If I want a library that scrapes web pages for me: BAM! `pip install beautifulsoup`. You get the idea. `pip` stores all the awesome libraries that people have built for Python and with a single command, you get access to them. Here's how to install it:
 
-* Ubuntu: `sudo apt-get install python-setuptools`
-* OSX: `ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go)"`
+* Ubuntu: 
+`curl -O http://python-distribute.org/distribute_setup.py
+python distribute_setup.py
+curl -O https://raw.github.com/pypa/pip/master/contrib/get-pip.py
+python get-pip.py`
+* OSX: Pip comes with Homebrew, no special setup needed.
 * Windows: insert Windows installation here
 
+Step 2: Set up your environment
+================================
 
-
-Installing `setuptools` will give you a command line tool called `easy_install`, which we'll use to install `virtualenv`.
+Installing `pip` allows us to easily install other packages, which we'll use to install `virtualenv`.
 
 Enter the following in your terminal to install `virtualenv`.
 ```
@@ -48,7 +50,6 @@ $ pip install virtualenv
 
 Now a quick word about `virtualenv`. It's a Python tool that allows you to create "sandboxes," or isolated environments in which you can code. When you need a Python library, you could install it globally, which means all your Python projects on your computer could use it. You could also install it locally, which means you install libraries on a project-by-project basis and no project will have any more dependencies available than it needs. The "sandbox" mentality means that we make sure each project stands alone, which means a lot when you may want to deploy these projects to remote computers.
 
-`virtualenv` comes with a "package manager" called `pip`. `pip` allows you to actually install libraries from online. Suppose I want to use a library that parses PDFs for me. BAM! `pip install pdfminer`. If I want a library that scrapes web pages for me: BAM! `pip install beautifulsoup`. You get the idea. `pip` stores all the awesome libraries that people have built for Python and with a single command, you get access to them.
 
 Now that you have `virtualenv` installed, you have to create a folder for your project.
 


### PR DESCRIPTION
added stuff for Mac.
Also, split Pip section out into it's own thing. Pip should be
installed before virtualenv. Mac OS X, installing homebrew to install
python means that Pip is installed before you even start THINKING about
installing virtualenv. The pip installation directions are unclear, so
I went digging into the
[history](https://pypi.python.org/pypi/setuptools/1.1.6#id104).

Originally, on the first day, after light and dark, God made python
setuptools; setuptools came with easy_install, which was a much easier
way to install python packages, and all was good. However, sin came
into the world and setuptools because old and not-quite-maintained.
Thus, Distribute came along, still with easy_install to install stuff.
Then from the tree of good and evil, came a better package manager in
the form of Pip.

So for a long time, installing distribute>pip was the best way to
install packages, as http://stackoverflow.com/a/5590714 shows. However,
distribute grew mature, and there came a time where the people who made
saw fit to merge it with the old setuptools, creating the new
setuptools. Pip followed suit, and from
https://github.com/pypa/pip/commit/0e342bc1297a4fde6d622d0f152161f3cbae9
162 we can see that it recommends new setuptools >=0.8.

Thus, the current best way to install the newest stuff is to $ wget
https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py | sudo
python && wget
https://raw.github.com/pypa/pip/master/contrib/get-pip.py | sudo
python. Aka install setuptools followed by pip.

Or perhaps, just $ sudo apt-get install python-setuptools python-pip

tl;dr pip comes before virtualenv, and figured out the proper way to install pip
